### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Gadzzaa/TrenchersPaperTrading/security/code-scanning/1](https://github.com/Gadzzaa/TrenchersPaperTrading/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so token scope is constrained by default.  
Best minimal fix here: define workflow-level permissions right after the trigger section (`on:`), applying to all jobs unless overridden.

For this workflow, `contents: read` is the minimal secure baseline CodeQL suggests and does not change existing functionality that depends on the separate `secrets.GH_TOKEN`.  
Edit only `.github/workflows/release.yml`, inserting:

- `permissions:`
- `  contents: read`

between the `on` block and `jobs`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
